### PR TITLE
Fix: API URL для тестов 21го потока

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -8,7 +8,7 @@ module.exports = defineConfig({
     excludeSpecPattern: '*.js',
     specPattern: 'cypress/integration/**/*.{feature,features}',
     baseUrl: 'http://localhost:8080',
-    baseApiUrl: 'https://21.objects.pages.academy/big-trip',
+    baseApiUrl: 'https://21.objects.htmlacademy.pro/big-trip',
     viewportHeight: 1000,
     viewportWidth: 1280,
     experimentalWebKitSupport: true,


### PR DESCRIPTION
Из-за смены адресов для апи тесты сломались, поэтому студенты не могли их запускать и тестировать проекты. Я поменял api url на актуальный, проверил на одной из работ студентов, всё вроде работает. 

Так как студенты взяли за работу 21й поток как актуальный, фикс именно для этого потока.

![image](https://github.com/htmlacademy/js2-big-trip-e2e/assets/12115788/449088ff-a6e2-466d-9ed5-3dfad816b60b)
